### PR TITLE
fix: remove the azurerm provider configuration block

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,10 +1,7 @@
 version: 2
-module_version: "0.0.5"
+module_version: "0.0.6"
 
 tests:
   - name: Test infrastructure creation
     runner_image: public.ecr.aws/spacelift/runner-terraform:azure-latest
-    environment:
-      TF_VAR_location: westeurope
-      TF_VAR_resource_group_name: self-hosted-v3-tf-testing
-      TF_VAR_app_domain: spacelift.example.com
+    project_root: "examples/simple"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ module "spacelift" {
   app_domain          = "spacelift.mycompany.com"
   location            = "polandcentral"
   resource_group_name = "testgrouptocreate"
-  subscription_id     = "00000000-0000-0000-0000-000000000000"
 }
 ```
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~>4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~>3.0"
+    }
+  }
+}
+
+variable "subscription_id" {
+  type = string
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+}
+
+module "spacelift" {
+  source = "../.."
+
+  app_domain          = "spacelift.example.com"
+  location            = "westeurope"
+  resource_group_name = "self-hosted-v3-tf-testing"
+}

--- a/provider.tf
+++ b/provider.tf
@@ -10,8 +10,3 @@ terraform {
     }
   }
 }
-
-provider "azurerm" {
-  features {}
-  subscription_id = var.subscription_id
-}

--- a/variables.tf
+++ b/variables.tf
@@ -13,11 +13,6 @@ variable "app_domain" {
   description = "The domain under which the Spacelift instance will be hosted"
 }
 
-variable "subscription_id" {
-  type        = string
-  description = "The subscription ID that will be used to create a resource group"
-}
-
 variable "k8s_namespace" {
   type        = string
   default     = "spacelift"


### PR DESCRIPTION
We should leave it up to consumers of the module to decide how to configure the provider.